### PR TITLE
[Rework] (core-view): `nj_create_view` Interface added + linux impl

### DIFF
--- a/examples/ipcexample.c
+++ b/examples/ipcexample.c
@@ -44,4 +44,14 @@ int main() {
   printf("Notified!\n");
 
   CloseHandle(obj.obj_handle);
+
+  ninjaview v = nj_create_view("nj_ipc_view", 1024);
+
+  nj_write_to_view(&v, "Melo48", strlen("Melo48"));
+  nj_write_to_view(&v, "Me", strlen("Me"));
+  nj_write_to_view(&v, "Mel", strlen("Mel"));
+
+  printf("View: %d!\nBuffer: %s\n", v.status, (char*)v.view_buffer);
+
+  CloseHandle(v.view_fd);
 }

--- a/examples/ipcexample.c
+++ b/examples/ipcexample.c
@@ -2,7 +2,7 @@
 #include "../src/ninjall.h"
 #include "../src/ninjasync.h"
 #include "../src/ninjaview.h"
-#include <Windows.h>
+// #include <Windows.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -11,47 +11,50 @@ void fn(const char *buf) { printf("[RECEIVED] %s\n", buf); }
 void fn2(const char *buf) { printf("[RECEIVED2] %s\n", buf); }
 void fn3(const char *buf) { printf("[RECEIVED3] %s\n", buf); }
 
-DWORD thread(LPVOID lparam) {
-	ninjasync *obj = (ninjasync*)lparam;
-	printf("Received: %p\n", obj->obj_handle);
-	Sleep(5000);
-	printf("Notifying...\n");
-	nj_notify_sync_obj(obj);
-	return 0;
-}
+// DWORD thread(LPVOID lparam) {
+// 	ninjasync *obj = (ninjasync*)lparam;
+// 	printf("Received: %p\n", obj->obj_handle);
+// 	Sleep(5000);
+// 	printf("Notifying...\n");
+// 	nj_notify_sync_obj(obj);
+// 	return 0;
+// }
 
 int main() {
-  ninjall_node *head = ll_init();
-  ll_register_callback(head, fn);
-  ll_register_callback(head, fn2);
-  ll_register_callback(head, fn3);
-  ll_notify_all_callbacks(head, ":)");
+  // ninjall_node *head = ll_init();
+  // ll_register_callback(head, fn);
+  // ll_register_callback(head, fn2);
+  // ll_register_callback(head, fn3);
+  // ll_notify_all_callbacks(head, ":)");
 
-  ninjasync obj = nj_create_sync_obj("nj_ipc_sync");
+  // ninjasync obj = nj_create_sync_obj("nj_ipc_sync");
 
-  if (obj.status) {
-	  printf("Created\n");
-  }
+  // if (obj.status) {
+  //  printf("Created\n");
+  // }
 
-  nj_bool st = nj_wait_notify_sync_obj_timed(&obj, 2000);
+  // nj_bool st = nj_wait_notify_sync_obj_timed(&obj, 2000);
 
-  printf("Timeout ? should be 0: (%d)\n", st);
+  // printf("Timeout ? should be 0: (%d)\n", st);
 
-  CreateThread(0, 0, thread, (LPVOID)&obj, 0, 0);
+  // CreateThread(0, 0, thread, (LPVOID)&obj, 0, 0);
 
-  nj_wait_notify_sync_obj(&obj);
-  
-  printf("Notified!\n");
+  // nj_wait_notify_sync_obj(&obj);
+  //
+  // printf("Notified!\n");
 
-  CloseHandle(obj.obj_handle);
+  // CloseHandle(obj.obj_handle);
 
   ninjaview v = nj_create_view("nj_ipc_view", 1024);
 
-  nj_write_to_view(&v, "Melo48", strlen("Melo48"));
-  nj_write_to_view(&v, "Me", strlen("Me"));
-  nj_write_to_view(&v, "Mel", strlen("Mel"));
+  if (v.status == nj_true) {
+    printf("Sucessfully view created!\n");
+  }
+  // nj_write_to_view(&v, "Melo48", strlen("Melo48"));
+  // nj_write_to_view(&v, "Me", strlen("Me"));
+  // nj_write_to_view(&v, "Mel", strlen("Mel"));
 
-  printf("View: %d!\nBuffer: %s\n", v.status, (char*)v.view_buffer);
+  printf("View: %d!\nBuffer: %s\n", v.status, (char *)v.view_buffer);
 
-  CloseHandle(v.view_fd);
+  //  CloseHandle(v.view_fd);
 }

--- a/examples/ipcexample.c
+++ b/examples/ipcexample.c
@@ -45,14 +45,24 @@ int main() {
 
   // CloseHandle(obj.obj_handle);
 
-  ninjaview v = nj_create_view("nj_ipc_view", 1024);
+  ninjaview wrong_v = nj_create_view("", 1024);
 
-  if (v.status == nj_true) {
-    printf("Sucessfully view created!\n");
+  if (wrong_v.status == nj_false) {
+    printf("Not accepted invalid name on view!\n");
   }
   // nj_write_to_view(&v, "Melo48", strlen("Melo48"));
   // nj_write_to_view(&v, "Me", strlen("Me"));
   // nj_write_to_view(&v, "Mel", strlen("Mel"));
+
+  ninjaview v = nj_create_view("ninjaview", 1024);
+
+  if (v.status == nj_true) {
+    printf("View sucessfully created!\n");
+  }
+
+  char text[] = "hello there, this is a simple text.";
+
+  memcpy(v.view_buffer, text, strlen(text) + 1);
 
   printf("View: %d!\nBuffer: %s\n", v.status, (char *)v.view_buffer);
 

--- a/src/linux/view.c
+++ b/src/linux/view.c
@@ -22,23 +22,7 @@
 #include <sys/mman.h>
 #include <sys/stat.h>
 
-nj_bool nj_write_to_view(ninjaview *view_obj, void *blob,
-                         unsigned int blob_size) {
-  // Set the entire buffer to zero for ensure the message passing
-  // clarity, for not getting any old buffer stuff
-  // if that occur proceed
-  if (memset(view_obj->view_buffer, '\0', view_obj->view_size)) {
-    // If blob not invalid
-    if (blob) {
-      // Copies the blob to the view buffer and returns nj_true
-      // if succesfully copied
-      if (memcpy(view_obj->view_buffer, blob, blob_size)) {
-        return nj_true;
-      }
-    }
-    // Blob invalid
-    return nj_false;
-  }
-  // Memset failed
-  return nj_false;
+ninjaview nj_create_view(unsigned int view_size) {
+  ninjaview view;
+  return view;
 }

--- a/src/ninjaview.h
+++ b/src/ninjaview.h
@@ -17,11 +17,32 @@
  */
 
 #include "ninjaerr.h"
+#include <memory.h>
 
 typedef struct ninjaview {
+  void* view_fd;
   void *view_buffer;
   unsigned int view_size;
+  nj_bool status;
 } ninjaview;
 
-nj_bool nj_write_to_view(ninjaview *view_obj, void *blob,
-                         unsigned int blob_size);
+ninjaview nj_create_view(const char *view_name, unsigned int view_size);
+
+inline nj_bool nj_write_to_view(ninjaview *view_obj, void *blob,
+                                unsigned int blob_size) {
+  // Clear buffer
+  if (memset(view_obj->view_buffer, '\0', view_obj->view_size)) {
+    // If blob not invalid
+    if (blob) {
+      // Copies the blob to the view buffer and returns nj_true
+      // if succesfully copied
+      if (memcpy(view_obj->view_buffer, blob, blob_size)) {
+        return nj_true;
+      }
+    }
+    // Blob invalid
+    return nj_false;
+  }
+  // Memset failed
+  return nj_false;
+}


### PR DESCRIPTION
This PR adds `nj_create_view` interface and a field on `ninjaview` representing the file handle (fd on linux, HANDLE on win32).

Closes https://github.com/oluan/ninjaipc/issues/13 https://github.com/oluan/ninjaipc/issues/11